### PR TITLE
PLAT-496 Implement runner auto-upgrade

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,34 +4,40 @@
 #
 # Environment variables:
 #
+# RUNNER_ENV_FILE
+#   The absolute path to the "softicar-github-runner.env" file on the host.
+#   Mandatory; default: (undefined)
+#
+# RUNNER_VERSION_OVERRIDE
+#   Enforces the "runner" service/image to be built with the specified version of GitHub Actions Runner.
+#   If undefined, the latest available version will be used.
+#   Optional; default: (undefined)
+#
 # NEXUS_CHECK_INTERVAL
 #   The polling interval for the "nexus" service health check.
-#   Default: "5s"
+#   Optional; default: "5s"
 #
 # NEXUS_CHECK_RETRIES
 #   The number of retries for the "nexus" service health check.
-#   Default: "20"
+#   Optional; default: "20"
 #
 # NEXUS_CHECK_START_PERIOD
 #   The time to wait until the first "nexus" service health check.
-#   Default: "80s"
+#   Optional; default: "80s"
 #
 # NEXUS_CHECK_TIMEOUT
 #   The amount of time after which an individual "nexus" service health check is considered failed.
 #   Should be smaller than NEXUS_CHECK_INTERVAL.
-#   Default: "4s"
+#   Optional; default: "4s"
 #
 # NEXUS_VERSION
 #   The version of the "sonatype/nexus3" image.
-#   Default: "3.34.1"
+#   Optional; default: "3.34.1"
 #
 # RUNNER_BUILD_PROPERTIES_FILE
 #   The absolute path to the "build.properties" file on the host.
-#   Default: "/home/softicar/.softicar/build.properties"
-#
-# RUNNER_ENV_FILE
-#   The absolute path to the "softicar-github-runner.env" file on the host.
-#   Default: "/home/softicar/.softicar/softicar-github-runner.env"
+#   Optional; default: "/home/softicar/.softicar/build.properties"
+#   TODO remove this. this was only necessary to define access to Ivy repos which we won't use anymore.
 
 version: "3.4"
 services:
@@ -51,19 +57,26 @@ services:
 
   runner:
     container_name: runner
-    build: ./runner
     image: softicar/softicar-github-runner
+    build:
+      context: ./runner
+      # Arguments required at image build time.
+      args:
+        - RUNNER_VERSION_OVERRIDE=${RUNNER_VERSION_OVERRIDE}
+    env_file:
+      # Arguments required at container run time.
+      - ${RUNNER_ENV_FILE}
     depends_on:
       nexus:
         condition: service_healthy
     runtime: sysbox-runc
-    env_file:
-      - ${RUNNER_ENV_FILE:-/home/softicar/.softicar/softicar-github-runner.env}
     volumes:
+    # TODO remove this. this was only necessary to define access to Ivy repos which we won't use anymore.
       - "${RUNNER_BUILD_PROPERTIES_FILE:-/home/softicar/.softicar/build.properties}:/home/softicar/.softicar/build.properties:ro"
     links:
       - nexus
 
 volumes:
+  # A non-prefixed volume that is created if necessary.
   nexus-data:
-    external: true
+    name: nexus-data

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -4,13 +4,6 @@
 # see https://github.com/nestybox/dockerfiles/blob/master/ubuntu-focal-systemd-docker/Dockerfile
 FROM nestybox/ubuntu-focal-systemd-docker
 
-# Define versions
-ARG ADOPT_OPEN_JDK_VERSION_DIR=15.0.2+7
-ARG ADOPT_OPEN_JDK_VERSION_FILE=15.0.2_7
-ARG DOCKER_COMPOSE_VERSION=1.27.4
-ARG DUMB_INIT_VERSION=1.2.2
-ARG GITHUB_RUNNER_VERSION=2.283.3
-
 # Add "softicar" user, and add them to required groups.
 # Remove default admin user (as defined in https://github.com/nestybox/dockerfiles/blob/master/ubuntu-focal-systemd/Dockerfile)
 RUN useradd -m softicar \
@@ -21,6 +14,8 @@ RUN useradd -m softicar \
 
 # Install JDK
 # see https://github.com/AdoptOpenJDK
+ARG ADOPT_OPEN_JDK_VERSION_DIR=15.0.2+7
+ARG ADOPT_OPEN_JDK_VERSION_FILE=15.0.2_7
 WORKDIR /opt
 RUN curl -Ls -o jdk.tar.gz https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-${ADOPT_OPEN_JDK_VERSION_DIR}/OpenJDK15U-jdk_x64_linux_hotspot_${ADOPT_OPEN_JDK_VERSION_FILE}.tar.gz \
     && tar xzf ./jdk.tar.gz \
@@ -42,22 +37,29 @@ RUN apt-get update \
 
 # Install docker-compose
 # see https://github.com/docker/compose/
+ARG DOCKER_COMPOSE_VERSION=1.27.4
 RUN curl -Ls -o /usr/local/bin/docker-compose https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-Linux-x86_64 \
     && chmod +x /usr/local/bin/docker-compose
 
+# Install dumb-init, for subsequent use as entrypoint
+# see https://github.com/Yelp/dumb-init
+ARG DUMB_INIT_VERSION=1.2.2
+RUN curl -Ls -o /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v${DUMB_INIT_VERSION}/dumb-init_${DUMB_INIT_VERSION}_x86_64 \
+    && chmod +x /usr/local/bin/dumb-init
+
 # Install GitHub Actions Runner
 # see https://github.com/actions/runner
+ARG RUNNER_VERSION_OVERRIDE
 WORKDIR /runner
-RUN curl -Ls -o runner.tar.gz https://github.com/actions/runner/releases/download/v${GITHUB_RUNNER_VERSION}/actions-runner-linux-x64-${GITHUB_RUNNER_VERSION}.tar.gz \
+RUN curl -Ls -o runner.tar.gz $( \
+      [ $RUNNER_VERSION_OVERRIDE ] \
+      && echo "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION_OVERRIDE}/actions-runner-linux-x64-${RUNNER_VERSION_OVERRIDE}.tar.gz" \
+      || echo $(curl -Ls https://api.github.com/repos/actions/runner/releases/latest | grep -oP '(?<="browser_download_url": ")[^"]*' | grep linux-x64) \
+    ) \
     && tar xzf ./runner.tar.gz \
     && rm ./runner.tar.gz \
     && ./bin/installdependencies.sh \
     && rm -rf /var/lib/apt/lists/*
-
-# Install dumb-init, for subsequent use as entrypoint
-# see https://github.com/Yelp/dumb-init
-RUN curl -Ls -o /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v${DUMB_INIT_VERSION}/dumb-init_${DUMB_INIT_VERSION}_x86_64 \
-    && chmod +x /usr/local/bin/dumb-init
 
 # Get stuff going
 COPY startup.sh /usr/local/bin/

--- a/softicar-github-runner.env-example
+++ b/softicar-github-runner.env-example
@@ -1,5 +1,5 @@
 # This is an exemplary environment file, to be used upon softicar-github-runner container startup.
-# Copy this to /home/softicar/.softicar/softicar-github-runner.env, chmod it to 600, and define the variables.
+# Copy this to /home/<user>/.softicar/softicar-github-runner.env, chmod it to 600, and define the variables.
 
 # The name of the runner, as displayed in the GitHub UI.
 # Must not be empty.
@@ -16,7 +16,7 @@
 # Must not be quoted.
 # GITHUB_REPOSITORY=Prevent-DEV/com.softicar.some-repo
 
-# A personal access token of a CI bot user of the GitHub organization.
+# The personal access token of a CI bot user of the GitHub organization.
 # Must not be empty.
 # Must not be quoted.
 # The token should be set to NEVER expire.

--- a/softicar-github-runner.service-template
+++ b/softicar-github-runner.service-template
@@ -11,6 +11,7 @@ Requires=docker.service
 TimeoutStartSec=0
 Restart=always
 User=%%SERVICE_USER%%
+Environment="RUNNER_ENV_FILE=%%RUNNER_ENV_FILE%%"
 ExecStart=%%SERVICE_SCRIPT_PATH%%
 
 [Install]

--- a/softicar-github-runner.sh
+++ b/softicar-github-runner.sh
@@ -11,22 +11,29 @@ SCRIPT_PATH=$(cd `dirname $0` && pwd)
 # Unregisters the previously registered runner.
 teardown() {
   echo "Shutting down containers..."
-  docker-compose -f $SCRIPT_PATH/docker-compose.yml down --timeout $COMPOSE_DOWN_TIMEOUT
-  echo "Containers were shut down."
+  if docker-compose -f $SCRIPT_PATH/docker-compose.yml down --timeout $COMPOSE_DOWN_TIMEOUT; then
+    echo "Containers were shut down."
+    exit 0
+  else
+    echo "FATAL: Failed to shut down containers."
+    exit 1
+  fi
 }
 
 # Traps various signals that could terminate this script, to perform cleanup operations.
 # Exits with 128+n for any trapped signal with an ID of n (cf. `kill -l`).
 trap_signals() {
-  trap 'teardown; exit 130;' SIGINT
-  trap 'teardown; exit 143;' SIGTERM
+  trap 'teardown;' SIGINT
+  trap 'teardown;' SIGTERM
 }
 
 check_prerequisites() {
-  [[ ! $(which docker) ]] && { echo "Fatal: Docker is not installed."; exit 1; }
-  docker ps > /dev/null 2>&1 || { echo "Fatal: User ${USER} has insufficient permissions for docker commands."; exit 1; }
-  [[ ! $(which docker-compose) ]] && { echo "Fatal: Docker-Compose is not installed."; exit 1; }
-  [[ ! $(which sysbox-runc) ]] && { echo "Fatal: The 'sysbox' Docker runc is not installed."; exit 1; }
+  [[ ! $(which docker) ]] && { echo "FATAL: Docker is not installed."; exit 1; }
+  docker ps > /dev/null 2>&1 || { echo "FATAL: User ${USER} has insufficient permissions for docker commands."; exit 1; }
+  [[ ! $(which docker-compose) ]] && { echo "FATAL: Docker-Compose is not installed."; exit 1; }
+  [[ ! $(which sysbox-runc) ]] && { echo "FATAL: The 'sysbox' Docker runc is not installed."; exit 1; }
+  [ -z $RUNNER_ENV_FILE ] && { echo "FATAL: 'RUNNER_ENV_FILE' must be defined."; exit 1; }
+  [ ! -f $RUNNER_ENV_FILE ] && { echo "FATAL: Failed to access RUNNER_ENV_FILE=$RUNNER_ENV_FILE (no such file)"; exit 1; }
 }
 
 # -------------------------------- Main Script -------------------------------- #
@@ -35,10 +42,16 @@ check_prerequisites
 
 trap_signals
 
+# Source all environment variables from $RUNNER_ENV_FILE and export them,
+# to make them available to all child processes spawned by docker-compose.
+# This is particularly important to have the variables available during
+# re-builds of the "runner" image.
+set -o allexport && source $RUNNER_ENV_FILE && set +o allexport
+
 # Remove the old "runner" before (re-)starting it, to reset its content.
-# TODO this might print an error message - beautify that
 docker-compose -f $SCRIPT_PATH/docker-compose.yml rm -f runner
 
-# Make sure that "nexus" gets or remains started, and that "runner" gets (re-)started
+# Make sure that "nexus" gets or remains started, and that "runner" gets
+# (re-)built and (re-)started.
 docker-compose -f $SCRIPT_PATH/docker-compose.yml up -d nexus && \
 docker-compose -f $SCRIPT_PATH/docker-compose.yml up --build runner


### PR DESCRIPTION
- `docker-compose.yml`:
  - Introduced `RUNNER_VERSION_OVERRIDE`.
  - `RUNNER_ENV_FILE` is now mandatory - removed the default (no more hard-coding to the `softicar` user).
  - Re-worded descriptions of environment variables.
  - Fixed `nexus-data` volume not being created if necessary.
  - Added some `TODO`s.
- `runner/Dockerfile`:
  - Runner version is no longer hard-coded. Instead, the most recent runner release is used. Can be overridden by defining `RUNNER_VERSION_OVERRIDE`.
  - Tweaked order of arguments and installation commands, to efficiently reuse layers from previous builds. (e.g. avoids unnecessary re-download of JDK when runner version changed)
- `service.sh`:
  - The path to the environment file is now determined at service installation time, and no longer hard-coded to the `soficar` user.
  - Fixed service not being stopped before uninstallation.
  - Improved wording of echoed messages, and added some more.
- `softicar-github-runner.sh`:
  - Now requires the path to an existing environment file, provided via `RUNNER_ENV_FILE`.
  - Now exits with 0 when the service is stopped. Avoids `systemctl status <service>` displaying `failed` state after a regular stop.
