### PR TITLE
PLAT-533 Throttle service restarts

### DIFF
--- a/softicar-github-runner.service-template
+++ b/softicar-github-runner.service-template
@@ -10,6 +10,7 @@ Requires=docker.service
 [Service]
 TimeoutStartSec=0
 Restart=always
+RestartSec=10
 User=%%SERVICE_USER%%
 Environment="RUNNER_ENV_FILE=%%RUNNER_ENV_FILE%%"
 ExecStart=%%SERVICE_SCRIPT_PATH%%


### PR DESCRIPTION
Limits service restart attempts (e.g. after abnormal termination) to "once per 10 seconds", instead of spamming them.
