### PR TITLE
PLAT-534 Reduce shutdown timeout

### DIFF
--- a/softicar-github-runner.sh
+++ b/softicar-github-runner.sh
@@ -5,7 +5,7 @@
 # Invoked by softicar-github-runner.service
 
 # Constants
-COMPOSE_DOWN_TIMEOUT=120
+COMPOSE_DOWN_TIMEOUT=30
 SCRIPT_PATH=$(cd `dirname $0` && pwd)
 
 # Unregisters the previously registered runner.


### PR DESCRIPTION
According to observations, shutdowns take max. 10 seconds. A timeout of 120 seconds therefore appeared excessive.
