### PR TITLE
PLAT-538 Stop the service before uninstalling

### DIFF
--- a/service.sh
+++ b/service.sh
@@ -36,7 +36,8 @@ function service_install {
 function service_uninstall {
   if [[ -f $SERVICE_FILE_DESTINATION ]]; then
     echo "Uninstalling service..."
-    sudo systemctl disable --now $SERVICE_FILE > /dev/null 2>&1 && \
+    sudo systemctl stop $SERVICE_FILE > /dev/null 2>&1 && \
+    sudo systemctl disable $SERVICE_FILE > /dev/null 2>&1 && \
     sudo rm $SERVICE_FILE_DESTINATION && \
     sudo systemctl daemon-reload && \
     echo "Service uninstalled."


### PR DESCRIPTION
This should have worked already via the `--now` switch, judging from the sytemd man pages - but it did not. So, we now explicitly stop the service.
