### PR TITLE
PLAT-529 Rework handling of environment variables

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,46 +2,41 @@
 #
 # Invoked by softicar-github-runner.sh
 #
-# -------- Mandatory Environment Variables --------
-#
-# RUNNER_ENV_FILE
-#   The absolute path to the "softicar-github-runner.env" file on the host.
-#   Mandatory; via environment variable
-#   Default: (undefined)
-#
-# -------- Optional Environment Variables --------
-#
-# RUNNER_VERSION_OVERRIDE
-#   Enforces the "runner" service/image to be built with the specified version of GitHub Actions Runner.
-#   If undefined, the latest available version will be used.
-#   Optional; via softicar-github-runner.env
-#   Default: (undefined)
+# The following environment variables may optionally be defined via "softicar-github-runner.env":
 #
 # NEXUS_CHECK_INTERVAL
 #   The polling interval for the "nexus" service health check.
-#   Optional; via softicar-github-runner.env
-#   Default: "5s"
 #
 # NEXUS_CHECK_RETRIES
 #   The number of retries for the "nexus" service health check.
-#   Optional; via softicar-github-runner.env
-#   Default: "20"
 #
 # NEXUS_CHECK_START_PERIOD
 #   The time to wait until the first "nexus" service health check.
-#   Optional; via softicar-github-runner.env
-#   Default: "80s"
 #
 # NEXUS_CHECK_TIMEOUT
 #   The amount of time after which an individual "nexus" service health check is considered failed.
-#   Should be smaller than NEXUS_CHECK_INTERVAL.
-#   Optional; via softicar-github-runner.env
-#   Default: "4s"
+#   Must be smaller than NEXUS_CHECK_INTERVAL.
 #
 # NEXUS_VERSION
 #   The version of the "sonatype/nexus3" image.
-#   Optional; via softicar-github-runner.env
-#   Default: "3.34.1"
+#
+# RUNNER_ADOPT_OPEN_JDK_VERSION
+#   The "Adopt OpenJDK" version to use in the runner.
+#
+# RUNNER_DOCKER_COMPOSE_VERSION
+#   The "Docker Compose" version to use in the runner.
+#
+# RUNNER_DOCKER_DAEMON_CONFIG
+#   The content of the "daemon.json" file for the Docker engine in the runner.
+#
+# RUNNER_DUMB_INIT_VERSION
+#   The "Dumb-Init" version to use in the runner.
+#
+# RUNNER_VERSION_OVERRIDE
+#   Explicitly defines the GitHub Actions Runner version with which the runner is built (see https://github.com/actions/runner/releases).
+#   Can be used to downgrade to an older GitHub Actions Runner version.
+#   If undefined, the latest available version will be used.
+#   Undefined by default. Should remain undefined unless absolutely necessary.
 
 version: "3.4"
 services:
@@ -65,12 +60,17 @@ services:
     image: softicar/softicar-github-runner
     build:
       context: ./runner
-      # Arguments required at image build time.
       args:
+        - RUNNER_ADOPT_OPEN_JDK_VERSION=${RUNNER_ADOPT_OPEN_JDK_VERSION:-15.0.2+7}
+        - RUNNER_DOCKER_COMPOSE_VERSION=${RUNNER_DOCKER_COMPOSE_VERSION:-1.27.4}
+        - RUNNER_DUMB_INIT_VERSION=${RUNNER_DUMB_INIT_VERSION:-1.2.2}
         - RUNNER_VERSION_OVERRIDE=${RUNNER_VERSION_OVERRIDE}
-    env_file:
-      # Arguments required at container run time.
-      - ${RUNNER_ENV_FILE}
+    environment:
+      - GITHUB_REPOSITORY=${GITHUB_REPOSITORY}
+      - GITHUB_RUNNER_LABELS=${GITHUB_RUNNER_LABELS}
+      - GITHUB_RUNNER_NAME=${GITHUB_RUNNER_NAME}
+      # TODO this should not be here -- instead, the runner token should be passed
+      - GITHUB_PERSONAL_ACCESS_TOKEN=${GITHUB_PERSONAL_ACCESS_TOKEN}
     depends_on:
       nexus:
         condition: service_healthy

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -14,12 +14,12 @@ RUN useradd -m softicar \
 
 # Install JDK
 # see https://github.com/AdoptOpenJDK
-ARG ADOPT_OPEN_JDK_VERSION_DIR=15.0.2+7
-ARG ADOPT_OPEN_JDK_VERSION_FILE=15.0.2_7
+ARG RUNNER_ADOPT_OPEN_JDK_VERSION
 WORKDIR /opt
-RUN curl -Ls -o jdk.tar.gz https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-${ADOPT_OPEN_JDK_VERSION_DIR}/OpenJDK15U-jdk_x64_linux_hotspot_${ADOPT_OPEN_JDK_VERSION_FILE}.tar.gz \
+RUN RUNNER_ADOPT_OPEN_JDK_VERSION_FILE=$(echo $RUNNER_ADOPT_OPEN_JDK_VERSION | sed 's/+/_/') \
+    && curl -Ls -o jdk.tar.gz https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-${RUNNER_ADOPT_OPEN_JDK_VERSION}/OpenJDK15U-jdk_x64_linux_hotspot_${RUNNER_ADOPT_OPEN_JDK_VERSION_FILE}.tar.gz \
     && tar xzf ./jdk.tar.gz \
-    && ln -s jdk-${ADOPT_OPEN_JDK_VERSION_DIR} jdk \
+    && ln -s jdk-${RUNNER_ADOPT_OPEN_JDK_VERSION} jdk \
     && rm ./jdk.tar.gz
 ENV PATH="/opt/jdk/bin:${PATH}"
 
@@ -37,14 +37,14 @@ RUN apt-get update \
 
 # Install docker-compose
 # see https://github.com/docker/compose/
-ARG DOCKER_COMPOSE_VERSION=1.27.4
-RUN curl -Ls -o /usr/local/bin/docker-compose https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-Linux-x86_64 \
+ARG RUNNER_DOCKER_COMPOSE_VERSION
+RUN curl -Ls -o /usr/local/bin/docker-compose https://github.com/docker/compose/releases/download/${RUNNER_DOCKER_COMPOSE_VERSION}/docker-compose-Linux-x86_64 \
     && chmod +x /usr/local/bin/docker-compose
 
 # Install dumb-init, for subsequent use as entrypoint
 # see https://github.com/Yelp/dumb-init
-ARG DUMB_INIT_VERSION=1.2.2
-RUN curl -Ls -o /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v${DUMB_INIT_VERSION}/dumb-init_${DUMB_INIT_VERSION}_x86_64 \
+ARG RUNNER_DUMB_INIT_VERSION
+RUN curl -Ls -o /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v${RUNNER_DUMB_INIT_VERSION}/dumb-init_${RUNNER_DUMB_INIT_VERSION}_x86_64 \
     && chmod +x /usr/local/bin/dumb-init
 
 # Install GitHub Actions Runner
@@ -62,8 +62,8 @@ RUN curl -Ls -o runner.tar.gz $( \
     && rm -rf /var/lib/apt/lists/*
 
 # Create Docker daemon configuration
-ARG DOCKER_DAEMON_CONFIG='{ "insecure-registries" : ["nexus:8123"], "registry-mirrors": ["http://nexus:8123/"] }'
-RUN mkdir -p /etc/docker/ && echo "$DOCKER_DAEMON_CONFIG" > /etc/docker/daemon.json
+ARG RUNNER_DOCKER_DAEMON_CONFIG='{ "insecure-registries" : ["nexus:8123"], "registry-mirrors": ["http://nexus:8123/"] }'
+RUN mkdir -p /etc/docker/ && echo "$RUNNER_DOCKER_DAEMON_CONFIG" > /etc/docker/daemon.json
 
 # Copy the startup script
 COPY startup.sh /usr/local/bin/

--- a/runner/startup.sh
+++ b/runner/startup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Validate environment variables
-[[ -z "$GITHUB_PERSONAL_TOKEN" ]] && { echo "FATAL: GITHUB_PERSONAL_TOKEN must not be empty." ; exit 1; }
+[[ -z "$GITHUB_PERSONAL_ACCESS_TOKEN" ]] && { echo "FATAL: GITHUB_PERSONAL_ACCESS_TOKEN must not be empty." ; exit 1; }
 [[ -z "$GITHUB_REPOSITORY" ]] && { echo "FATAL: GITHUB_REPOSITORY must not be empty." ; exit 1; }
 [[ -z "$GITHUB_RUNNER_NAME" ]] && { echo "FATAL: GITHUB_RUNNER_NAME must not be empty." ; exit 1; }
 
@@ -11,7 +11,7 @@ REGISTRATION_URL="https://github.com/${GITHUB_REPOSITORY}"
 # Generates a new runner token, using a personal access token.
 generate_runner_token() {
   echo "Generating runner token..."
-  TOKEN_RESPONSE=$(curl -sX POST -H "Authorization: token ${GITHUB_PERSONAL_TOKEN}" "${AUTH_URL}")
+  TOKEN_RESPONSE=$(curl -sX POST -H "Authorization: token ${GITHUB_PERSONAL_ACCESS_TOKEN}" "${AUTH_URL}")
   RUNNER_TOKEN=$(echo "${TOKEN_RESPONSE}" | jq .token --raw-output)
 
   if [ "${RUNNER_TOKEN}" == "null" ]

--- a/softicar-github-runner.env-example
+++ b/softicar-github-runner.env-example
@@ -1,52 +1,14 @@
-# Exemplary environment file for the SoftiCAR GitHub Runner.
-# Copy this to /home/<user>/.softicar/softicar-github-runner.env, and chmod it to 600.
-# Make sure to define all "MANDATORY" variables.
-
+# Environment file for the SoftiCAR GitHub Runner
 #
-# The name of the runner, as displayed in the GitHub UI.
+# Should be located at "/home/<user>/.softicar/softicar-github-runner.env", where "<user>"
+# is the user defined in the SoftiCAR GitHub Runner systemd service.
 #
-# MANDATORY
-# Must not be quoted.
-GITHUB_RUNNER_NAME=softicar-github-runner
-
+# For a list of environment variables to define in this file, refer to "docker-compose.yml".
 #
-# Additional labels for the runner.
+# "docker-compose.yml" defines a default value of each of those variables. To override it,
+# add a key-value pair as exemplified below.
 #
-# OPTIONAL
-# Comma-separated.
-# Must not contain spaces.
-# Must not be quoted.
-GITHUB_RUNNER_LABELS=ephemeral,dind
-
+# Do NOT quote the value unless you know what you're doing.
 #
-# The owner/name of the GitHub repo to build.
-#
-# MANDATORY
-# Must not be quoted.
-# GITHUB_REPOSITORY=Prevent-DEV/com.softicar.some-repo
-
-#
-# The personal access token of a build-bot user of the GitHub organization.
-#
-# MANDATORY
-# The token should be set to NEVER expire.
-# The token must provide the following scopes (permissions):
-#   repo (all)
-#   workflow
-#   read:org
-#   read:public_key
-#   read:repo_hook
-#   admin:org_hook
-#   notifications
-# Must not be quoted.
-# GITHUB_PERSONAL_TOKEN=the-personal-access-token
-
-#
-# Enforce a specific release version of GitHub Actions Runner (see https://github.com/actions/runner/releases).
-#
-# OPTIONAL -- !! SHOULD REMAIN UNDEFINED, UNLESS ABSOLUTELY NECESSARY !!
-# Can be used to downgrade to an older release version.
-# If undefined, the latest release version will be used.
-# Must not start with a "v".
-# Must not be quoted.
-# RUNNER_VERSION_OVERRIDE=1.234.5
+# Example:
+# SOME_VARIABLE=some value

--- a/softicar-github-runner.service-template
+++ b/softicar-github-runner.service-template
@@ -1,7 +1,3 @@
-# A systemd service that manages the SoftiCAR GitHub Runner lifecycle.
-#
-# Install with: ./service.sh install
-
 [Unit]
 Description=SoftiCAR GitHub Runner
 After=docker.service
@@ -13,6 +9,10 @@ Restart=always
 RestartSec=10
 User=%%SERVICE_USER%%
 Environment="RUNNER_ENV_FILE=%%RUNNER_ENV_FILE%%"
+Environment="GITHUB_REPOSITORY=%%GITHUB_REPOSITORY%%"
+Environment="GITHUB_RUNNER_NAME=%%GITHUB_RUNNER_NAME%%"
+Environment="GITHUB_RUNNER_LABELS=%%GITHUB_RUNNER_LABELS%%"
+Environment="GITHUB_PERSONAL_ACCESS_TOKEN=%%GITHUB_PERSONAL_ACCESS_TOKEN%%"
 ExecStart=%%SERVICE_SCRIPT_PATH%%
 
 [Install]

--- a/softicar-github-runner.sh
+++ b/softicar-github-runner.sh
@@ -32,8 +32,6 @@ check_prerequisites() {
   docker ps > /dev/null 2>&1 || { echo "FATAL: User ${USER} has insufficient permissions for docker commands."; exit 1; }
   [[ ! $(which docker-compose) ]] && { echo "FATAL: Docker-Compose is not installed."; exit 1; }
   [[ ! $(which sysbox-runc) ]] && { echo "FATAL: The 'sysbox' Docker runc is not installed."; exit 1; }
-  [ -z $RUNNER_ENV_FILE ] && { echo "FATAL: 'RUNNER_ENV_FILE' must be defined."; exit 1; }
-  [ ! -f $RUNNER_ENV_FILE ] && { echo "FATAL: Failed to access RUNNER_ENV_FILE=${RUNNER_ENV_FILE} (no such file)"; exit 1; }
 }
 
 # -------------------------------- Main Script -------------------------------- #
@@ -42,11 +40,10 @@ check_prerequisites
 
 trap_signals
 
-# Source all environment variables from $RUNNER_ENV_FILE and export them,
-# to make them available to all child processes spawned by docker-compose.
-# This is particularly important to have the variables available during
-# re-builds of the "runner" image.
-set -o allexport && source $RUNNER_ENV_FILE && set +o allexport
+# If $RUNNER_ENV_FILE exists, source it and export all contained environment variables, to make them
+# available to all child processes spawned by docker-compose.
+# This is particularly important to have the variables available during re-builds of the "runner" image.
+[ -f $RUNNER_ENV_FILE ] && set -o allexport && source $RUNNER_ENV_FILE && set +o allexport
 
 # Remove the old "runner" before (re-)starting it, to reset its content.
 docker-compose -f $SCRIPT_PATH/docker-compose.yml rm -f runner


### PR DESCRIPTION
Prepared the upcoming change to generate the runner token before starting the runner container.
Therefore simplified and centralized definition and passing of environment variables, and made it more consistent.

Details:
- The PAT and other mandatory environment variables are no longer expected in `softicar-github-runner.env`.
- Instead, they are prompted for during service installation, and baked into `/etc/systemd/system/softicar-github-runner.service`.
- Added validation of entered variables, as part of the respective prompt.
- `softicar-github-runner.env` is now completely optional. It may still be used to override default environment variables.
- Default values for build-time environment variables are now centralized in `docker-compose.yml` (and no longer scattered across `docker-compose.yml` and `Dockerfile`).

Additional minor changes:
- `Dockerfile`: Added `RUNNER_` prefix to all arguments, and merged `ADOPT_OPEN_JDK` version arguments.
- `startup.sh`: Renamed `GITHUB_PERSONAL_TOKEN` to `GITHUB_PERSONAL_ACCESS_TOKEN`.
- `docker-compose.yml`: Re-worded variable descriptions to no longer contain default values.
- `service.sh`: Re-ordered variables.
