### PR TITLE
PLAT-529 Generate the runner token outside the runner container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,8 +69,7 @@ services:
       - GITHUB_REPOSITORY=${GITHUB_REPOSITORY}
       - GITHUB_RUNNER_LABELS=${GITHUB_RUNNER_LABELS}
       - GITHUB_RUNNER_NAME=${GITHUB_RUNNER_NAME}
-      # TODO this should not be here -- instead, the runner token should be passed
-      - GITHUB_PERSONAL_ACCESS_TOKEN=${GITHUB_PERSONAL_ACCESS_TOKEN}
+      - GITHUB_RUNNER_TOKEN=${GITHUB_RUNNER_TOKEN}
     depends_on:
       nexus:
         condition: service_healthy

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -25,13 +25,11 @@ ENV PATH="/opt/jdk/bin:${PATH}"
 
 # Install Java test-runtime dependencies:
 #   git -- to clone repos
-#   jq -- required by the script invoked with CMD
 #   libfontconfig1 -- required during Java test runtime
 # Afterwards, clear the apt package lists (see https://docs.docker.com/develop/develop-images/dockerfile_best-practices/).
 RUN apt-get update \
     && apt-get install -y \
        git \
-       jq \
        libfontconfig1 \
     && rm -rf /var/lib/apt/lists/*
 

--- a/service.sh
+++ b/service.sh
@@ -97,7 +97,6 @@ function assert_installed {
 # A variable must be given as an argument. The return value is written to that variable.
 function prompt_for_service_user() {
   while true; do
-    echo ""
     read -erp "Enter the service user [$USER]: "
     local REPLY=${REPLY:-$USER}
     if [[ $REPLY = 'root' ]]; then echo "Please enter a non-root user."
@@ -112,7 +111,6 @@ function prompt_for_service_user() {
 # A variable must be given as an argument. The return value is written to that variable.
 function prompt_for_repository() {
   while true; do
-    echo ""
     read -erp "Enter the repository to build (e.g. $REPOSITORY_NAME_EXAMPLE): "
     local REPLY=${REPLY}
     if [[ -z $REPLY ]]; then echo "Please enter a repository."
@@ -127,7 +125,6 @@ function prompt_for_repository() {
 # A variable must be given as an argument. The return value is written to that variable.
 function prompt_for_runner_name() {
   while true; do
-    echo ""
     read -erp "Enter the name of this runner [$RUNNER_NAME_DEFAULT]: "
     local REPLY=${REPLY:-$RUNNER_NAME_DEFAULT}
     if ! [[ $REPLY =~ $RUNNER_NAME_REGEX ]]; then echo "Please enter a runner name that matches the following regex: $RUNNER_NAME_REGEX"
@@ -140,7 +137,6 @@ function prompt_for_runner_name() {
 # Prompts for the labels of the spawned runner.
 # A variable must be given as an argument. The return value is written to that variable.
 function prompt_for_runner_labels() {
-  echo ""
   read -erp "Enter a comma-separated list of labels for this runner [$RUNNER_LABELS_DEFAULT]: "
   local REPLY=${REPLY:-$RUNNER_LABELS_DEFAULT}
   eval $1="'$REPLY'"
@@ -150,8 +146,7 @@ function prompt_for_runner_labels() {
 # A variable must be given as an argument. The return value is written to that variable.
 function prompt_for_personal_access_token() {
   while true; do
-    read -erp $'
-Enter the Personal Access Token of a build-bot user, with:
+    read -erp $'Enter the Personal Access Token of a build-bot user, with:
   Expire: never
   Scopes:
     repo (all)

--- a/softicar-github-runner.sh
+++ b/softicar-github-runner.sh
@@ -32,6 +32,27 @@ check_prerequisites() {
   docker ps > /dev/null 2>&1 || { echo "FATAL: User ${USER} has insufficient permissions for docker commands."; exit 1; }
   [[ ! $(which docker-compose) ]] && { echo "FATAL: Docker-Compose is not installed."; exit 1; }
   [[ ! $(which sysbox-runc) ]] && { echo "FATAL: The 'sysbox' Docker runc is not installed."; exit 1; }
+  [[ ! $(which jq) ]] && { echo "FATAL: 'jq' is not installed."; exit 1; }
+}
+
+# Generates a new runner token, using a personal access token.
+generate_runner_token() {
+  echo "Generating runner token..."
+  [[ -z "$GITHUB_PERSONAL_ACCESS_TOKEN" ]] && { echo "FATAL: GITHUB_PERSONAL_ACCESS_TOKEN must be defined." ; exit 1; }
+  [[ -z "$GITHUB_REPOSITORY" ]] && { echo "FATAL: GITHUB_REPOSITORY must be defined." ; exit 1; }
+
+  local auth_url="https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runners/registration-token"
+  local token_response=$(curl -sX POST -H "Authorization: token ${GITHUB_PERSONAL_ACCESS_TOKEN}" "${auth_url}")
+  GITHUB_RUNNER_TOKEN=$(echo "${token_response}" | jq .token --raw-output)
+
+  if [ "${GITHUB_RUNNER_TOKEN}" == "null" ]
+  then
+    echo "Failed to generate runner token: ${token_response}"
+    exit 1
+  else
+    echo "Runner token generated."
+    export GITHUB_RUNNER_TOKEN
+  fi
 }
 
 # -------------------------------- Main Script -------------------------------- #
@@ -44,6 +65,8 @@ trap_signals
 # available to all child processes spawned by docker-compose.
 # This is particularly important to have the variables available during re-builds of the "runner" image.
 [ -f $RUNNER_ENV_FILE ] && set -o allexport && source $RUNNER_ENV_FILE && set +o allexport
+
+generate_runner_token
 
 # Remove the old "runner" before (re-)starting it, to reset its content.
 docker-compose -f $SCRIPT_PATH/docker-compose.yml rm -f runner


### PR DESCRIPTION
- `GITHUB_PERSONAL_ACCESS_TOKEN` is no longer passed to the runner container.
- `GITHUB_RUNNER_TOKEN` is now generated in `softicar-github-runner.sh`
- `jq` is no longer needed in the runner container but on the host (where it is available anyway, as a sysbox dependency).

Test Plan:
- Log in to a running runner container.
- Execute `cat /proc/1/environ | tr '\0' '\n' | grep TOKEN`
- Observe that `GITHUB_PERSONAL_ACCESS_TOKEN` is no longer contained in the output.
