### PR TITLE
PLAT-545 Move service installation to setup.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,36 +36,36 @@ The following things are required to set up _SoftiCAR GitHub Runner_ on a VM:
 1. Log in to the GitHub UI with your personal account:
    - At `Settings` / `Manage Access` of the repository to build, add the build-bot user as an `Admin`.
 1. Log in to the VM, as a non-root user.
-   - If the user has an RSA key pair which is also used on another machine, **delete it**.
+1. Add a public RSA key in the GitHub UI:
+   - If the VM user has an RSA key pair which is also used on another machine, **delete it** and **generate a new one**.
      - Do _not_ reuse an existing key pair for this machine.
      - Delete `id_rsa` and `id_rsa.pub` from `/home/<user>/.ssh/`
      - If existing, delete `id_rsa` and `id_rsa.pub` from `/root/.ssh/` as well.
-   - Run `ssh-keygen` to generate a new key pair in `/home/<user>/.ssh/`
-   - In the GitHub UI, at `(Build-Bot User Profile)` / `Settings` / `SSH and GPG keys`, add the content of the generated `id_rsa.pub` file.
+     - Run `ssh-keygen` to generate a new key pair in `/home/<user>/.ssh/`
+   - In the GitHub UI, at `(Build-Bot User Profile)` / `Settings` / `SSH and GPG keys`, add the content of `id_rsa.pub`
 1. Install `git`:
 
        sudo apt install git
 
 1. Clone this repository.
-1. Use the setup script to install all required components (i.e. Docker, Docker-Compose, GitHub CLI, and Sysbox):
+1. Use the setup script to install _all_ required components (i.e. Docker, Docker-Compose, Sysbox, and a Systemd Service):
 
        ./setup install
 
    - Answer to various prompts.
    - When prompted for a Personal Access Token (PAT), log in to the GitHub UI with the build-bot account.
-   - Head to `(Build-Bot User Profile)` / `Settings` / `Developer settings` / `Personal access tokens`.
+   - Head to `(Build-Bot User Profile)` / `Settings` / `Developer settings` / `Personal access tokens`
    - Create a PAT with settings and scopes as described in the terminal prompt.
-   - Copy and paste the PAT into the terminal prompt. **Watch out for leading and tailing whitespaces!**
-1. Reboot the VM afterwards.
+   - Copy and paste the PAT into the terminal prompt.
 1. **Optionally,** copy `softicar-github-runner-service.env-example` to `/home/<user>/.softicar/softicar-github-runner-service.env`
-   - This is only necessary if default settings shall be overridden -- e.g. if a specific [GitHub Actions Runner](https://github.com/actions/runner) version shall be enforced.
+   - Normally, this environment file is _not_ required.
+   - Yet, it _can_ be used to override some default settings -- e.g. if a specific [GitHub Actions Runner](https://github.com/actions/runner) version shall be enforced.
    - Refer to the comments in [softicar-github-runner-service.env-example](systemd-service/softicar-github-runner-service.env-example) and [softicar-github-runner-service-docker-compose.yml](systemd-service/softicar-github-runner-service-docker-compose.yml) for details.
-1. Install and start the systemd service: _(TODO rework this step when service installation gets migrated into setup.sh)_
+1. Reboot the VM.
+1. Make sure that the systemd service is `active (running)`:
 
-       ./control.sh install
-       ./control.sh start
+       ./control.sh status
 
-   - Note that `install` will also _enable_ the service, i.e. set it to auto-start after reboots.
 1. Configure the _nexus_ container as a pull-though cache proxy for build dependencies:
    1. Finish the first-time setup wizard of the _nexus_ container:
       - Look up the default password of the `admin` user in `/var/lib/docker/volumes/nexus-data/_data/admin.password`
@@ -107,10 +107,17 @@ The following things are required to set up _SoftiCAR GitHub Runner_ on a VM:
             -PdependencyProxy=http://nexus:8081/repository/maven-central/
 
 1. In the GitHub UI, under `Settings` / `Actions` / `Runners` of the project to build, make sure that the runner is listed as `Idle`.
-1. Make sure that no errors are reported in the outputs of:
+1. Make sure that no errors are reported in the output of:
 
-       ./control.sh status
        ./control.sh logs
+
+   You can _follow_ the output with:
+
+       ./control.sh logs -f
+
+   For all available control commands, enter:
+
+       ./control.sh
 
 ## 4 Limitations
 

--- a/common.sh
+++ b/common.sh
@@ -1,0 +1,70 @@
+# Defines common environment variables and functions for the scripts in this folder.
+#
+# Sourced by other scripts.
+
+SCRIPT_SUPPORTED_RELEASES=focal
+SCRIPT_WORKING_DIRECTORY=$(cd `dirname $0` && pwd)
+
+DOCKER_COMPOSE_VERSION=1.29.2
+DOCKER_COMPOSE_DESTINATION=/usr/bin/docker-compose
+DOCKER_COMPOSE_HOME=/opt/docker-compose
+DOCKER_COMPOSE_FILE=$DOCKER_COMPOSE_HOME/docker-compose-Linux-x86_64-$DOCKER_COMPOSE_VERSION
+
+SERVICE_FILE=softicar-github-runner.service
+SERVICE_FILE_DESTINATION=/etc/systemd/system/$SERVICE_FILE
+SERVICE_SCRIPT_ENVIRONMENT_FILE=softicar-github-runner-service.env
+SERVICE_SCRIPT_PATH=$SCRIPT_WORKING_DIRECTORY/systemd-service/softicar-github-runner-service.sh
+SERVICE_TEMPLATE_PATH=systemd-service/softicar-github-runner.service-template
+
+SYSBOX_VERSION=0.4.1
+SYSBOX_UBUNTU_RELEASE=focal
+
+REPOSITORY_NAME_EXAMPLE="<owner>/<repository>"
+REPOSITORY_NAME_REGEX="[a-zA-Z0-9]([_.-]?[a-zA-Z0-9]+)*/[a-zA-Z0-9]([_.-]?[a-zA-Z0-9]+)*"
+
+RUNNER_LABELS_DEFAULT="ephemeral,dind"
+RUNNER_NAME_DEFAULT="softicar-github-runner"
+RUNNER_NAME_REGEX="[a-zA-Z0-9]([_.-]?[a-zA-Z0-9]+)*"
+
+function is_docker_installed() {
+  if [[ $(which docker) ]]; then true; else false; fi
+}
+
+function assert_docker_installed() {
+  ! is_docker_installed && { echo "Docker is not installed. Install it with: ./setup.sh"; exit 1; }
+}
+
+function is_docker_compose_installed() {
+  if [[ -f $DOCKER_COMPOSE_DESTINATION ]]; then true; else false; fi
+}
+
+function assert_docker_compose_installed() {
+  ! is_docker_compose_installed && { echo "Docker-Compose is not installed. Install it with: ./setup.sh"; exit 1; }
+}
+
+function is_service_installed() {
+  if [[ -f $SERVICE_FILE_DESTINATION ]]; then true; else false; fi
+}
+
+function assert_service_installed() {
+  ! is_service_installed && { echo "Service is not installed. Install it with: ./setup.sh"; exit 1; }
+}
+
+function is_sysbox_installed() {
+  if [[ $(which sysbox-runc) ]]; then true; else false; fi
+}
+
+function assert_sysbox_installed() {
+  ! is_sysbox_installed && { echo "Sysbox is not installed. Install it with: ./setup.sh"; exit 1; }
+}
+
+function print_release_warning_if_necessary {
+  local system_release=$(lsb_release -cs)
+  if [[ ! $SCRIPT_SUPPORTED_RELEASES == *"$system_release"* ]]; then
+    echo ""
+    echo "WARNING:"
+    echo "The following Ubuntu releases are supported: $SCRIPT_SUPPORTED_RELEASES"
+    echo "This system is based upon: $system_release"
+    echo "The setup script is not guaranteed to work properly on this system."
+  fi
+}

--- a/control.sh
+++ b/control.sh
@@ -51,6 +51,8 @@ function print_help {
   echo "  start            Start the service"
   echo "  status           Show the service status"
   echo "  stop             Stop the service"
+
+  print_release_warning_if_necessary
 }
 
 # -------------------------------- Main Script -------------------------------- #

--- a/control.sh
+++ b/control.sh
@@ -2,69 +2,17 @@
 
 # SoftiCAR GitHub Runner - Systemd Service Control Script
 #
-# Facilitates installation, administration and uninstallation of the
-# systemd service that manages the SoftiCAR GitHub Runner lifecycle.
+# Facilitates administration of the systemd service that manages the SoftiCAR GitHub Runner lifecycle.
 #
 # Run without parameters for a list of available commands.
-#
-# TODO migrate "install" and "uninstall" to setup.sh - those have no place in here
 
-SELF_PATH=$(cd `dirname $0` && pwd)
-SERVICE_FILE=softicar-github-runner.service
-SERVICE_FILE_DESTINATION=/etc/systemd/system/$SERVICE_FILE
-SERVICE_TEMPLATE_PATH=systemd-service/softicar-github-runner.service-template
-SERVICE_SCRIPT_PATH=$SELF_PATH/systemd-service/softicar-github-runner-service.sh
-SERVICE_SCRIPT_ENVIRONMENT_FILE=softicar-github-runner-service.env
-RUNNER_NAME_DEFAULT="softicar-github-runner"
-RUNNER_NAME_REGEX="[a-zA-Z0-9]([_.-]?[a-zA-Z0-9]+)*"
-RUNNER_LABELS_DEFAULT="ephemeral,dind"
-REPOSITORY_NAME_EXAMPLE="<owner>/<repository>"
-REPOSITORY_NAME_REGEX="[a-zA-Z0-9]([_.-]?[a-zA-Z0-9]+)*/[a-zA-Z0-9]([_.-]?[a-zA-Z0-9]+)*"
+source common.sh
 
-function service_install {
-  if [[ ! -f $SERVICE_FILE_DESTINATION ]]; then
-    echo "Installing service..."
+# -------------------------------- Functions -------------------------------- #
 
-    [[ -f $SERVICE_TEMPLATE_PATH ]] || { echo "FATAL: Could not find the service template at $SERVICE_TEMPLATE_PATH"; exit 1; }
-    [[ -f $SERVICE_SCRIPT_PATH ]] || { echo "FATAL: Could not find the service script at $SERVICE_SCRIPT_PATH"; exit 1; }
-
-    prompt_for_service_user SERVICE_USER
-    prompt_for_repository GITHUB_REPOSITORY
-    prompt_for_runner_name GITHUB_RUNNER_NAME
-    prompt_for_runner_labels GITHUB_RUNNER_LABELS
-    prompt_for_personal_access_token GITHUB_PERSONAL_ACCESS_TOKEN
-    RUNNER_ENV_FILE="/home/${SERVICE_USER}/.softicar/${SERVICE_SCRIPT_ENVIRONMENT_FILE}"
-
-    SERVICE_FILE_CONTENT=$(cat $SERVICE_TEMPLATE_PATH \
-                           | sed "s:%%SERVICE_USER%%:${SERVICE_USER}:" \
-                           | sed "s:%%SERVICE_SCRIPT_PATH%%:${SERVICE_SCRIPT_PATH}:" \
-                           | sed "s:%%RUNNER_ENV_FILE%%:${RUNNER_ENV_FILE}:" \
-                           | sed "s:%%GITHUB_REPOSITORY%%:${GITHUB_REPOSITORY}:" \
-                           | sed "s:%%GITHUB_RUNNER_NAME%%:${GITHUB_RUNNER_NAME}:" \
-                           | sed "s:%%GITHUB_RUNNER_LABELS%%:${GITHUB_RUNNER_LABELS}:" \
-                           | sed "s:%%GITHUB_PERSONAL_ACCESS_TOKEN%%:${GITHUB_PERSONAL_ACCESS_TOKEN}:" \
-                         )
-    sudo bash -c "echo '$SERVICE_FILE_CONTENT' > $SERVICE_FILE_DESTINATION" && \
-    sudo chmod 644 $SERVICE_FILE_DESTINATION && \
-    sudo systemctl daemon-reload && \
-    sudo systemctl enable $SERVICE_FILE > /dev/null 2>&1 && \
-    echo "Service installed and enabled. Start it with: $0 start"
-  else
-    echo "Service is already installed. Nothing to do."; exit 0;
-  fi
-}
-
-function service_uninstall {
-  if [[ -f $SERVICE_FILE_DESTINATION ]]; then
-    echo "Uninstalling service..."
-    sudo systemctl stop $SERVICE_FILE > /dev/null 2>&1 && \
-    sudo systemctl disable $SERVICE_FILE > /dev/null 2>&1 && \
-    sudo rm $SERVICE_FILE_DESTINATION && \
-    sudo systemctl daemon-reload && \
-    echo "Service uninstalled."
-  else
-    echo "Service is not installed. Nothing to do."; exit 0;
-  fi
+function service_logs {
+  assert_service_installed
+  journalctl -u $SERVICE_FILE $TAILING_PARAMS
 }
 
 function service_status {
@@ -75,6 +23,10 @@ function service_status {
 function service_start {
   assert_service_installed
   echo "Starting service..."
+  assert_docker_installed
+  assert_docker_compose_installed
+  assert_sysbox_installed
+
   sudo systemctl start $SERVICE_FILE && \
   echo "Service started."
 }
@@ -82,89 +34,9 @@ function service_start {
 function service_stop {
   assert_service_installed
   echo "Stopping service..."
+
   sudo systemctl stop $SERVICE_FILE && \
   echo "Service stopped."
-}
-
-function service_logs {
-  assert_service_installed
-  journalctl -u $SERVICE_FILE $TAILING_PARAMS
-}
-
-function assert_service_installed {
-  [[ -f $SERVICE_FILE_DESTINATION ]] || { echo "Service is not installed."; exit 1; }
-}
-
-# Prompts for the name of an existing local user.
-# A variable must be given as an argument. The return value is written to that variable.
-function prompt_for_service_user() {
-  while true; do
-    read -erp "Enter the service user [$USER]: "
-    local REPLY=${REPLY:-$USER}
-    if [[ $REPLY = 'root' ]]; then echo "Please enter a non-root user."
-    elif ! `id $REPLY > /dev/null 2>&1`; then echo "User '$REPLY' does not exist."
-    else break
-    fi
-  done
-  eval $1="'$REPLY'"
-}
-
-# Prompts for the name of a GitHub repository, in "SoftiCAR/some-repo" format.
-# A variable must be given as an argument. The return value is written to that variable.
-function prompt_for_repository() {
-  while true; do
-    read -erp "Enter the repository to build (e.g. $REPOSITORY_NAME_EXAMPLE): "
-    local REPLY=${REPLY}
-    if [[ -z $REPLY ]]; then echo "Please enter a repository."
-    elif ! [[ $REPLY =~ $REPOSITORY_NAME_REGEX ]]; then echo "Please enter a repository name in the following format: $REPOSITORY_NAME_EXAMPLE"
-    else break
-    fi
-  done
-  eval $1="'$REPLY'"
-}
-
-# Prompts for the name of the spawned runner.
-# A variable must be given as an argument. The return value is written to that variable.
-function prompt_for_runner_name() {
-  while true; do
-    read -erp "Enter the name of this runner [$RUNNER_NAME_DEFAULT]: "
-    local REPLY=${REPLY:-$RUNNER_NAME_DEFAULT}
-    if ! [[ $REPLY =~ $RUNNER_NAME_REGEX ]]; then echo "Please enter a runner name that matches the following regex: $RUNNER_NAME_REGEX"
-    else break
-    fi
-  done
-  eval $1="'$REPLY'"
-}
-
-# Prompts for the labels of the spawned runner.
-# A variable must be given as an argument. The return value is written to that variable.
-function prompt_for_runner_labels() {
-  read -erp "Enter a comma-separated list of labels for this runner [$RUNNER_LABELS_DEFAULT]: "
-  local REPLY=${REPLY:-$RUNNER_LABELS_DEFAULT}
-  eval $1="'$REPLY'"
-}
-
-# Prompts for a GitHub Personal Access Token.
-# A variable must be given as an argument. The return value is written to that variable.
-function prompt_for_personal_access_token() {
-  while true; do
-    read -erp $'Enter the Personal Access Token of a build-bot user, with:
-  Expire: never
-  Scopes:
-    repo (all)
-    workflow
-    read:org
-    read:public_key
-    read:repo_hook
-    admin:org_hook
-    notifications
-Token: '
-    local REPLY=${REPLY}
-    if [[ -z $REPLY ]]; then echo "Please enter a Personal Access Token."
-    else break
-    fi
-  done
-  eval $1="'$REPLY'"
 }
 
 function print_help {
@@ -174,13 +46,11 @@ function print_help {
   echo "  $0 [COMMAND]"
   echo ""
   echo "Commands:"
-  echo "  install          Install the service, and enable it"
   echo "  logs             Show the service logs"
   echo "                   Tailing parameters are forwarded to 'journalctl', e.g. '-f' or '-r'"
   echo "  start            Start the service"
   echo "  status           Show the service status"
   echo "  stop             Stop the service"
-  echo "  uninstall        Uninstall the service"
 }
 
 # -------------------------------- Main Script -------------------------------- #
@@ -188,9 +58,7 @@ function print_help {
 TAILING_PARAMS="${@:2}"
 
 case $1 in
-  "install") service_install;;
   "logs") service_logs;;
-  "uninstall") service_uninstall;;
   "status") service_status;;
   "start") service_start;;
   "stop") service_stop;;

--- a/setup.sh
+++ b/setup.sh
@@ -6,14 +6,11 @@
 #
 # Run without parameters for a list of available commands.
 
-DOCKER_COMPOSE_VERSION=1.29.2
-DOCKER_COMPOSE_HOME=/opt/docker-compose
-DOCKER_COMPOSE_FILE=$DOCKER_COMPOSE_HOME/docker-compose-Linux-x86_64-$DOCKER_COMPOSE_VERSION
-DOCKER_COMPOSE_TARGET=/usr/bin/docker-compose
-SYSBOX_VERSION=0.4.1
-SYSBOX_UBUNTU_RELEASE=focal
+source common.sh
+
 REBOOT_HINT=false
-SUPPORTED_UBUNTU_RELEASES="focal"
+
+# -------------------------------- Functions -------------------------------- #
 
 function install_components() {
   if [[ -n $TAILING_PARAMS ]]; then
@@ -47,7 +44,7 @@ function install_component() {
   case $1 in
     "docker") install_docker;;
     "docker-compose") install_docker_compose;;
-    "gh") install_gh;;
+    "service") install_service;;
     "sysbox") install_sysbox;;
     *) echo -e "Unknown component: $1\n\n"; print_help;;
   esac
@@ -57,7 +54,7 @@ function uninstall_component() {
   case $1 in
     "docker") uninstall_docker;;
     "docker-compose") uninstall_docker_compose;;
-    "gh") uninstall_gh;;
+    "service") uninstall_service;;
     "sysbox") uninstall_sysbox;;
     *) echo -e "Unknown component: $1\n\n"; print_help;;
   esac
@@ -66,18 +63,18 @@ function uninstall_component() {
 function install_all() {
   install_docker && \
   install_docker_compose && \
-  install_gh && \
-  install_sysbox
+  install_sysbox && \
+  install_service
 
   echo ""
   print_components_status
 }
 
 function uninstall_all() {
+  uninstall_service && \
   uninstall_sysbox && \
   uninstall_docker_compose && \
-  uninstall_docker && \
-  uninstall_gh
+  uninstall_docker
 
   echo ""
   print_components_status
@@ -86,7 +83,7 @@ function uninstall_all() {
 function install_docker() {
   if ! is_docker_installed; then
     echo -e "\nInstalling Docker..."
-    prompt_for_docker_user
+    prompt_for_docker_user $DOCKER_USER
 
     sudo apt update && \
     sudo apt install --no-install-recommends -y apt-transport-https ca-certificates curl gnupg-agent software-properties-common && \
@@ -122,7 +119,7 @@ function install_docker_compose() {
     sudo mkdir -p $DOCKER_COMPOSE_HOME && \
     sudo wget -O $DOCKER_COMPOSE_FILE https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-Linux-x86_64 && \
     sudo chmod +x $DOCKER_COMPOSE_FILE && \
-    sudo ln -sf $DOCKER_COMPOSE_FILE $DOCKER_COMPOSE_TARGET && \
+    sudo ln -sf $DOCKER_COMPOSE_FILE $DOCKER_COMPOSE_DESTINATION && \
     echo "Docker-Compose installed."
   else
     echo "Docker-Compose is already installed. Nothing to do."
@@ -132,37 +129,61 @@ function install_docker_compose() {
 function uninstall_docker_compose() {
   if is_docker_compose_installed; then
     echo -e "\nUninstalling Docker-Compose..."
-    [[ ! -L $DOCKER_COMPOSE_TARGET ]] && { echo "FATAL: Docker-Compose cannot be uninstalled because $DOCKER_COMPOSE_TARGET is not a symlink."; exit 1; }
+    [[ ! -L $DOCKER_COMPOSE_DESTINATION ]] && { echo "FATAL: Docker-Compose cannot be uninstalled because $DOCKER_COMPOSE_DESTINATION is not a symlink."; exit 1; }
 
-    sudo rm $DOCKER_COMPOSE_TARGET && \
+    sudo rm $DOCKER_COMPOSE_DESTINATION && \
     echo "Docker-Compose uninstalled."
   else
     echo "Docker-Compose is not installed. Nothing to do."
   fi
 }
 
-function install_gh() {
-  if ! is_gh_installed; then
-    echo -e "\nInstalling GitHub CLI..."
+function install_service {
+  if ! is_service_installed; then
+    echo -e "\nInstalling service..."
 
-    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo gpg --yes --dearmor -o /usr/share/keyrings/githubcli-archive-keyring.gpg && \
-    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \
-    sudo apt update && \
-    sudo apt install -y gh && \
-    echo "GitHub CLI installed."
+    [[ -f $SERVICE_TEMPLATE_PATH ]] || { echo "FATAL: Could not find the service template at $SERVICE_TEMPLATE_PATH"; exit 1; }
+    [[ -f $SERVICE_SCRIPT_PATH ]] || { echo "FATAL: Could not find the service script at $SERVICE_SCRIPT_PATH"; exit 1; }
+
+    prompt_for_service_user SERVICE_USER
+    prompt_for_repository GITHUB_REPOSITORY
+    prompt_for_runner_name GITHUB_RUNNER_NAME
+    prompt_for_runner_labels GITHUB_RUNNER_LABELS
+    prompt_for_personal_access_token GITHUB_PERSONAL_ACCESS_TOKEN
+    RUNNER_ENV_FILE="/home/${SERVICE_USER}/.softicar/${SERVICE_SCRIPT_ENVIRONMENT_FILE}"
+
+    SERVICE_FILE_CONTENT=$(cat $SERVICE_TEMPLATE_PATH \
+                           | sed "s:%%SERVICE_USER%%:${SERVICE_USER}:" \
+                           | sed "s:%%SERVICE_SCRIPT_PATH%%:${SERVICE_SCRIPT_PATH}:" \
+                           | sed "s:%%RUNNER_ENV_FILE%%:${RUNNER_ENV_FILE}:" \
+                           | sed "s:%%GITHUB_REPOSITORY%%:${GITHUB_REPOSITORY}:" \
+                           | sed "s:%%GITHUB_RUNNER_NAME%%:${GITHUB_RUNNER_NAME}:" \
+                           | sed "s:%%GITHUB_RUNNER_LABELS%%:${GITHUB_RUNNER_LABELS}:" \
+                           | sed "s:%%GITHUB_PERSONAL_ACCESS_TOKEN%%:${GITHUB_PERSONAL_ACCESS_TOKEN}:" \
+                         )
+    sudo bash -c "echo '$SERVICE_FILE_CONTENT' > $SERVICE_FILE_DESTINATION" && \
+    sudo chmod 644 $SERVICE_FILE_DESTINATION && \
+    sudo systemctl daemon-reload && \
+    sudo systemctl enable $SERVICE_FILE > /dev/null 2>&1 && \
+    echo "Service installed and enabled. Start it with: ./control.sh start"
   else
-    echo "GitHub CLI is already installed. Nothing to do."
+    echo "Service is already installed. Nothing to do."; exit 0;
   fi
 }
 
-function uninstall_gh() {
-  if is_gh_installed; then
-    echo -e "\nUninstalling GitHub CLI..."
+function uninstall_service {
+  if is_service_installed; then
+    echo -e "\nUninstalling service..."
+    echo "This will delete '$SERVICE_FILE_DESTINATION' which contains your Personal Access Token (PAT)."
+    prompt_boolean_default_no "Are you sure?" || { echo "Aborted."; exit 1; }
 
-    sudo apt remove -y gh && \
-    echo "GitHub CLI uninstalled."
+    sudo systemctl stop $SERVICE_FILE > /dev/null 2>&1 && \
+    sudo systemctl disable $SERVICE_FILE > /dev/null 2>&1 && \
+    sudo rm $SERVICE_FILE_DESTINATION && \
+    sudo systemctl daemon-reload && \
+    echo "Service uninstalled."
   else
-    echo "GitHub CLI is not installed. Nothing to do."
+    echo "Service is not installed. Nothing to do."; exit 0;
   fi
 }
 
@@ -192,54 +213,117 @@ function uninstall_sysbox() {
   fi
 }
 
-function is_docker_installed() {
-  if [[ $(which docker) ]]; then true; else false; fi
-}
-
-function is_docker_compose_installed() {
-  if [[ -f $DOCKER_COMPOSE_TARGET ]]; then true; else false; fi
-}
-
-function is_gh_installed() {
-  if [[ $(which gh) ]]; then true; else false; fi
-}
-
-function is_sysbox_installed() {
-  if [[ $(which sysbox-runc) ]]; then true; else false; fi
-}
-
 function is_running_containers() {
   if [[ $(docker ps -q) -gt 0 ]]; then true; else false; fi
 }
 
 function print_components_status() {
-  echo "COMPONENT           DESCRIPTION                     INSTALLED"
-  echo "docker              Docker Engine                   $(is_docker_installed && echo 'yes' || echo 'no')"
-  echo "docker-compose      Docker-Compose Script           $(is_docker_compose_installed && echo 'yes' || echo 'no')"
-  echo "gh                  GitHub command-line client      $(is_gh_installed && echo 'yes' || echo 'no')"
-  echo "sysbox              Sysbox Docker Runtime           $(is_sysbox_installed && echo 'yes' || echo 'no')"
+  echo "COMPONENT           DESCRIPTION                         INSTALLED"
+  echo "docker              Docker Engine                       $(is_docker_installed && echo 'yes' || echo 'no')"
+  echo "docker-compose      Docker-Compose Script               $(is_docker_compose_installed && echo 'yes' || echo 'no')"
+  echo "service             SoftiCAR GitHub Runner service      $(is_service_installed && echo 'yes' || echo 'no')"
+  echo "sysbox              Sysbox Docker Runtime               $(is_sysbox_installed && echo 'yes' || echo 'no')"
 }
 
 function print_reboot_hint_if_necessary() {
-  if $REBOOT_HINT; then echo -e "\nPlease reboot the system."; fi
+  if $REBOOT_HINT; then echo -e "\nPlease reboot this system."; fi
 }
 
+# Prompts for the name of an existing local user to interact with the Docker daemon.
+# A variable must be given as an argument. The return value is written to that variable.
 function prompt_for_docker_user() {
   while true; do
-    read -p "Enter the user who will interact with the Docker daemon [$USER]: "
-    DOCKER_USER=${REPLY:-$USER}
-    if [[ $DOCKER_USER = 'root' ]]; then echo "Please enter a non-root user."
-    elif ! `id $DOCKER_USER > /dev/null 2>&1`; then echo "User '$DOCKER_USER' does not exist."
+    read -erp "Enter the user who will interact with the Docker daemon [$USER]: "
+    local REPLY=${REPLY:-$USER}
+    if [[ $REPLY = 'root' ]]; then echo "Please enter a non-root user."
+    elif ! `id $REPLY > /dev/null 2>&1`; then echo "User '$REPLY' does not exist."
     else break
     fi
   done
+  eval $1="'$REPLY'"
 }
 
+# Prompts for the name of an existing local user to run the service.
+# A variable must be given as an argument. The return value is written to that variable.
+function prompt_for_service_user() {
+  while true; do
+    read -erp "Enter the service user [$USER]: "
+    local REPLY=${REPLY:-$USER}
+    if [[ $REPLY = 'root' ]]; then echo "Please enter a non-root user."
+    elif ! `id $REPLY > /dev/null 2>&1`; then echo "User '$REPLY' does not exist."
+    else break
+    fi
+  done
+  eval $1="'$REPLY'"
+}
+
+# Prompts for the name of a GitHub repository, in "SoftiCAR/some-repo" format.
+# A variable must be given as an argument. The return value is written to that variable.
+function prompt_for_repository() {
+  while true; do
+    read -erp "Enter the repository to build (e.g. $REPOSITORY_NAME_EXAMPLE): "
+    local REPLY=${REPLY}
+    if [[ -z $REPLY ]]; then echo "Please enter a repository."
+    elif ! [[ $REPLY =~ $REPOSITORY_NAME_REGEX ]]; then echo "Please enter a repository name in the following format: $REPOSITORY_NAME_EXAMPLE"
+    else break
+    fi
+  done
+  eval $1="'$REPLY'"
+}
+
+# Prompts for the name of the spawned runner.
+# A variable must be given as an argument. The return value is written to that variable.
+function prompt_for_runner_name() {
+  while true; do
+    read -erp "Enter the name of this runner [$RUNNER_NAME_DEFAULT]: "
+    local REPLY=${REPLY:-$RUNNER_NAME_DEFAULT}
+    if ! [[ $REPLY =~ $RUNNER_NAME_REGEX ]]; then echo "Please enter a runner name that matches the following regex: $RUNNER_NAME_REGEX"
+    else break
+    fi
+  done
+  eval $1="'$REPLY'"
+}
+
+# Prompts for the labels of the spawned runner.
+# A variable must be given as an argument. The return value is written to that variable.
+function prompt_for_runner_labels() {
+  read -erp "Enter a comma-separated list of labels for this runner [$RUNNER_LABELS_DEFAULT]: "
+  local REPLY=${REPLY:-$RUNNER_LABELS_DEFAULT}
+  eval $1="'$REPLY'"
+}
+
+# Prompts for a GitHub Personal Access Token.
+# A variable must be given as an argument. The return value is written to that variable.
+function prompt_for_personal_access_token() {
+  while true; do
+    read -erp $'Enter the Personal Access Token of a build-bot user, with:
+  Expire: never
+  Scopes:
+    repo (all)
+    workflow
+    read:org
+    read:public_key
+    read:repo_hook
+    admin:org_hook
+    notifications
+Token: '
+    local REPLY=${REPLY}
+    if [[ -z $REPLY ]]; then echo "Please enter a Personal Access Token."
+    else break
+    fi
+  done
+  eval $1="'$REPLY'"
+}
+
+# Prompts for a boolean response, and defaults to "y" (yes).
+# A variable must be given as an argument. Its content is used as prompt message.
 function prompt_boolean_default_yes() {
   read -p "$1 [Y/n]: " -r; REPLY=${REPLY:-"Y"};
   if [[ $REPLY =~ ^[Yy]$ ]]; then true; else false; fi
 }
 
+# Prompts for a boolean response, and defaults to "n" (no).
+# A variable must be given as an argument. Its content is used as prompt message.
 function prompt_boolean_default_no() {
   read -p "$1 [y/N]: " -r; REPLY=${REPLY:-"N"};
   if [[ $REPLY =~ ^[Yy]$ ]]; then true; else false; fi
@@ -260,21 +344,10 @@ function print_help {
   echo "  all                         (all components)"
   echo "  docker                      the Docker Engine"
   echo "  docker-compose              the Docker-Compose script"
-  echo "  gh                          the GitHub command-line client"
+  echo "  service                     the SoftiCAR GitHub Runner service"
   echo "  sysbox                      the Sysbox Docker runtime"
 
   print_release_warning_if_necessary
-}
-
-function print_release_warning_if_necessary {
-  SYSTEM_RELEASE=$(lsb_release -cs)
-  if [[ ! $SUPPORTED_UBUNTU_RELEASES == *"$SYSTEM_RELEASE"* ]]; then
-    echo ""
-    echo "WARNING:"
-    echo "The following Ubuntu releases are supported: $SUPPORTED_UBUNTU_RELEASES"
-    echo "This system is based upon: $SYSTEM_RELEASE"
-    echo "The setup script is not guaranteed to work properly on this system."
-  fi
 }
 
 # -------------------------------- Main Script -------------------------------- #


### PR DESCRIPTION
- Systemd service installation was moved from `control.sh` to `setup.sh`
  - The service is now merely another "component" to be handled by `setup.sh`
- Added `common.sh` to provide variables and function which are shared between `setup.sh` and `control.sh`
- `setup.sh`: Removed (un-)installation of `gh` - we don't need that any longer since we open-sourced the repo.
- Upon service un-installation, added a prompt to warn about the imminent deletion of the PAT.
- Updated `README.md` accordingly
