### PR TITLE
PLAT-548 Use sudo for journalctl

### DIFF
--- a/control.sh
+++ b/control.sh
@@ -28,7 +28,7 @@ function service_enable {
 
 function service_logs {
   assert_service_installed
-  journalctl -u $SERVICE_FILE $TAILING_PARAMS
+  sudo journalctl -u $SERVICE_FILE $TAILING_PARAMS
 }
 
 function service_status {


### PR DESCRIPTION
Depending on the system configuration, this can be necessary.
This is the case, e.g., for systems cloned from our server VM template.
