### PR TITLE
PLAT-727 Configure docker token security realm

### DIFF
--- a/nexus-image/Dockerfile
+++ b/nexus-image/Dockerfile
@@ -11,6 +11,7 @@ RUN mkdir -p ${NEXUS_CONFIG_DIR}
 COPY docker-hub.repository.json ${NEXUS_CONFIG_DIR}/
 COPY gradle-plugins.repository.json ${NEXUS_CONFIG_DIR}/
 COPY maven-central.repository.json ${NEXUS_CONFIG_DIR}/
+COPY security-realms.json ${NEXUS_CONFIG_DIR}/
 
 # Copy the startup and configuration scripts
 COPY startup.sh /usr/local/bin/

--- a/nexus-image/configure.sh
+++ b/nexus-image/configure.sh
@@ -41,6 +41,10 @@ configure_nexus() {
   curl -sf -u "admin:${new_password}" -X POST -H "Content-Type: application/json" -d "@$NEXUS_DATA_SOFTICAR_DIR/maven-central.repository.json" "${NEXUS_REST_BASE_URL}/v1/repositories/maven/proxy" -o /dev/null && \
   log "Added repository: maven-central"
 
+  # Configure security realms
+  curl -sf -u "admin:${new_password}" -X PUT -H "Content-Type: application/json" -d "@$NEXUS_DATA_SOFTICAR_DIR/security-realms.json" "${NEXUS_REST_BASE_URL}/v1/security/realms/active" -o /dev/null && \
+  log "Configured security realms."
+
   log "Finished configuration."
 }
 

--- a/nexus-image/security-realms.json
+++ b/nexus-image/security-realms.json
@@ -1,0 +1,5 @@
+[
+  "NexusAuthenticatingRealm",
+  "NexusAuthorizingRealm",
+  "DockerToken"
+]


### PR DESCRIPTION
For anonymous pulls from the `docker-hub` cache repo, we need to enable the `DockerToken` security realm. Otherwise, the repo will simply be skipped, and the docker daemon will fall back to the public DockerHub repo.

`NexusAuthenticatingRealm` and `NexusAuthorizingRealm` are enabled by default. However, there is no API option to _add_ a realm, so we must redefine all of those (see `security-realms.json`).