### PR TITLE
PLAT-777-2 Fix wrong runner archive being downloaded by default

### DIFF
--- a/runner-image/Dockerfile
+++ b/runner-image/Dockerfile
@@ -52,7 +52,7 @@ WORKDIR /runner
 RUN curl -Ls -o runner.tar.gz $( \
       [ $RUNNER_VERSION_OVERRIDE ] \
       && echo "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION_OVERRIDE}/actions-runner-linux-x64-${RUNNER_VERSION_OVERRIDE}.tar.gz" \
-      || echo $(curl -Ls https://api.github.com/repos/actions/runner/releases/latest | grep -oP '(?<="browser_download_url": ")[^"]*' | grep linux-x64) \
+      || echo $(curl -Ls https://api.github.com/repos/actions/runner/releases/latest | grep -oP '(?<="browser_download_url": ")[^"]*' | egrep 'linux-x64-[0-9\.]+\.tar\.gz') \
     ) \
     && tar xzf ./runner.tar.gz \
     && rm ./runner.tar.gz \


### PR DESCRIPTION
Before this PR, when no runner version was enforced, the nested `curl` command to fetch the latest runner version yielded:
```
https://github.com/actions/runner/releases/download/v2.289.2/actions-runner-linux-x64-2.289.2-noexternals.tar.gz
https://github.com/actions/runner/releases/download/v2.289.2/actions-runner-linux-x64-2.289.2-noruntime-noexternals.tar.gz
https://github.com/actions/runner/releases/download/v2.289.2/actions-runner-linux-x64-2.289.2-noruntime.tar.gz
https://github.com/actions/runner/releases/download/v2.289.2/actions-runner-linux-x64-2.289.2-trimmedpackages.json
https://github.com/actions/runner/releases/download/v2.289.2/actions-runner-linux-x64-2.289.2.tar.gz
```
The first of those files was downloaded, while we indeed need the last one, which explains the error about missing external `node` dependencies upon attempted builds:
```
Error: An error occurred trying to start process '/runner/externals/node12/bin/node' with working directory '/runner/_work/platform/platform'. No such file or directory
```

In this PR, the tailing `grep` was adjusted such that only the last URL (to `actions-runner-linux-x64-2.289.2.tar.gz`) is retained, and the correct archive is downloaded.
