### PR TITLE
PLAT-777-4 Decrease expected free disk space

### DIFF
--- a/nexus-image/Dockerfile
+++ b/nexus-image/Dockerfile
@@ -5,7 +5,7 @@ FROM sonatype/nexus3:${NEXUS_VERSION}
 
 USER root
 
-# Copy configuration scripts
+# Copy configuration files
 ARG NEXUS_CONFIG_DIR=/nexus-data/softicar
 RUN mkdir -p ${NEXUS_CONFIG_DIR}
 COPY docker-hub.repository.json ${NEXUS_CONFIG_DIR}/
@@ -13,11 +13,14 @@ COPY gradle-plugins.repository.json ${NEXUS_CONFIG_DIR}/
 COPY maven-central.repository.json ${NEXUS_CONFIG_DIR}/
 COPY security-realms.json ${NEXUS_CONFIG_DIR}/
 
-# Copy the startup and configuration scripts
+# Copy startup.sh and configure.sh
 COPY startup.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/startup.sh
 COPY configure.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/configure.sh
+
+# Configure Karaf subsystem properties
+RUN sed -i 's/storage.diskCache.diskFreeSpaceLimit=.*/storage.diskCache.diskFreeSpaceLimit=512/g' /opt/sonatype/nexus/etc/karaf/system.properties
 
 USER nexus
 CMD ["startup.sh"]


### PR DESCRIPTION
The database of the "Karaf" subsystem of Nexus will enter a read-only mode if free disk space is below `storage.diskCache.diskFreeSpaceLimit`. If this happens, new data cannot be added to our pull-through caches - and builds would fail.
`diskFreeSpaceLimit` defaults to 4096 MiB. However, as of a recent Docker update, free space inside the container seems to commonly be _below_ 4096 MiB.
So we simply reduce the threshold in this PR.
