### PR TITLE
PLAT-793 Extract RUNNER_RELEASE_DOWNLOAD_URL variable

### DIFF
--- a/runner-image/Dockerfile
+++ b/runner-image/Dockerfile
@@ -47,13 +47,9 @@ RUN curl -Ls -o /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/relea
 
 # Install GitHub Actions Runner
 # see https://github.com/actions/runner
-ARG RUNNER_VERSION_OVERRIDE
+ARG RUNNER_RELEASE_DOWNLOAD_URL
 WORKDIR /runner
-RUN curl -Ls -o runner.tar.gz $( \
-      [ $RUNNER_VERSION_OVERRIDE ] \
-      && echo "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION_OVERRIDE}/actions-runner-linux-x64-${RUNNER_VERSION_OVERRIDE}.tar.gz" \
-      || echo $(curl -Ls https://api.github.com/repos/actions/runner/releases/latest | grep -oP '(?<="browser_download_url": ")[^"]*' | egrep 'linux-x64-[0-9\.]+\.tar\.gz') \
-    ) \
+RUN curl -Ls -o runner.tar.gz ${RUNNER_RELEASE_DOWNLOAD_URL} \
     && tar xzf ./runner.tar.gz \
     && rm ./runner.tar.gz \
     && ./bin/installdependencies.sh \

--- a/systemd-service/softicar-github-runner-service-docker-compose.yml
+++ b/systemd-service/softicar-github-runner-service-docker-compose.yml
@@ -32,10 +32,10 @@
 # RUNNER_DUMB_INIT_VERSION
 #   The "Dumb-Init" version to use in the runner.
 #
-# RUNNER_VERSION_OVERRIDE
-#   Explicitly defines the GitHub Actions Runner version with which the runner is built (see https://github.com/actions/runner/releases).
-#   Can be used to downgrade to an older GitHub Actions Runner version.
-#   If undefined, the latest available version will be used.
+# RUNNER_RELEASE_DOWNLOAD_URL
+#   The URL of the GitHub Actions Runner .tar.gz archive with which the runner image is built (see https://github.com/actions/runner/releases).
+#   Can be used to downgrade to an older GitHub Actions Runner release.
+#   If undefined, the latest available release will be used.
 #   Undefined by default. Should remain undefined unless absolutely necessary.
 
 version: "3.4"
@@ -68,7 +68,7 @@ services:
         - RUNNER_ADOPT_OPEN_JDK_VERSION=${RUNNER_ADOPT_OPEN_JDK_VERSION:-15.0.2+7}
         - RUNNER_DOCKER_COMPOSE_VERSION=${RUNNER_DOCKER_COMPOSE_VERSION:-1.27.4}
         - RUNNER_DUMB_INIT_VERSION=${RUNNER_DUMB_INIT_VERSION:-1.2.2}
-        - RUNNER_VERSION_OVERRIDE=${RUNNER_VERSION_OVERRIDE}
+        - RUNNER_RELEASE_DOWNLOAD_URL=${RUNNER_RELEASE_DOWNLOAD_URL}
     environment:
       - GITHUB_REPOSITORY=${GITHUB_REPOSITORY}
       - GITHUB_RUNNER_LABELS=${GITHUB_RUNNER_LABELS}

--- a/systemd-service/softicar-github-runner-service.sh
+++ b/systemd-service/softicar-github-runner-service.sh
@@ -63,6 +63,12 @@ remove_dangling_images() {
   echo "Dangling images removed."
 }
 
+# Exports additional environment variables for pending container builds.
+export_additional_build_environment() {
+  local runner_latest_download_url=$(curl -Ls https://api.github.com/repos/actions/runner/releases/latest | grep -oP '(?<="browser_download_url": ")[^"]*' | egrep 'linux-x64-[0-9\.]+\.tar\.gz')
+  export RUNNER_RELEASE_DOWNLOAD_URL=${RUNNER_RELEASE_DOWNLOAD_URL:-$runner_latest_download_url}
+}
+
 # -------------------------------- Main Script -------------------------------- #
 
 check_prerequisites
@@ -73,6 +79,8 @@ trap_signals
 # available to all child processes spawned by docker-compose.
 # This is required to have those variables available when (re-)building the "runner" image.
 [ -f $RUNNER_ENV_FILE ] && set -o allexport && source $RUNNER_ENV_FILE && set +o allexport
+
+export_additional_build_environment
 
 generate_runner_token
 


### PR DESCRIPTION
Ensure a cache-miss upon image build time when the download URL changes.

That cache-miss is particularly desired when a new upstream version of GitHub Actions Runner was released.
